### PR TITLE
Docs: changed frontmatter from `layout` to `view`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Source file src/index.md:
 
 ```markdown
 ---
-layout: layout.html
+view: layout.html
 title: The title
 ---
 The Content


### PR DESCRIPTION
I noticed this option didn't match with the library itself, so updated the docs to reflect the correct `view` attribute.