### PR TITLE
Wrapped data.contents in a Buffer to prevent stream error 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ function plugin(opts) {
 			twig({
 				path: path,
 				load: function(template) {
-					data.contents = template.render(data);
+					data.contents = new Buffer(template.render(data), 'utf8');
 
 					done();
 				}


### PR DESCRIPTION
When using this plugin with `gulp-metalsmith`, I noticed that it expected a Buffer on `data.contents`, as opposed to a string. So I've wrapped it. I've also tested it without gulp to check it still works.